### PR TITLE
Award at most one teammate request

### DIFF
--- a/cyslf/models.py
+++ b/cyslf/models.py
@@ -117,6 +117,7 @@ class Team:
         return (
             f"Team {self.name:11} "
             f"({self.practice_day} "
+            f"{self.location} "
             f"size={len(self.players)}, "
             f"skill={self.get_skill():.2f}, "
             f"grade={self.get_grade():.2f})"

--- a/cyslf/scorers/core.py
+++ b/cyslf/scorers/core.py
@@ -52,6 +52,7 @@ class TeammateScorer:
     """
 
     def __init__(self, players: List["Player"], teams: List["Team"]):
+        # Assumes teams are empty, which is technically how we do it
         self.league_size = len(players)
         self.friend_matches = 0
 
@@ -79,6 +80,7 @@ class TeammateScorer:
             name = f"{p.first_name} {p.last_name}"
             if name in player.teammate_requests and not request_satisfied:
                 self.friend_matches -= 1
+                request_satisfied = True
             if f"{player.first_name} {player.last_name}" in p.teammate_requests:
                 player_is_unique = True
                 for q in team.players:
@@ -91,7 +93,7 @@ class TeammateScorer:
                     self.friend_matches -= 1
 
     def get_score(self) -> float:
-        return self.friend_matches / self.league_size / 2
+        return self.friend_matches / self.league_size
 
 
 # PARITY SCORERS

--- a/cyslf/validation.py
+++ b/cyslf/validation.py
@@ -25,7 +25,11 @@ def validate_player_strs(player: "Player"):
 
 
 def validate_player_ints(player: "Player"):
-    for key in ["grade", "skill", "goalie_skill"]:
+    for key, minimum, maximum in [
+        ("grade", -1, 8),
+        ("skill", 1, 10),
+        ("goalie_skill", 1, 10),
+    ]:
         value = player.__getattribute__(key)
         if not isinstance(value, int) and not isinstance(value, float):
             raise ValueError(
@@ -33,10 +37,11 @@ def validate_player_ints(player: "Player"):
                 f"number but found {key}={value} ({type(value)}) instead. Please correct this in "
                 "the input csv and retry"
             )
-        if value < 1 or value > 10:
+        if value < minimum or value > maximum:
             raise ValueError(
                 f"Failed to create player {player.first_name} {player.last_name}. {key} ({value}) "
-                "is unexpectedly < 1 or > 10. Please correct this in the input csv and retry."
+                f"is unexpectedly < {minimum} or > {maximum}. Please correct this in the input csv "
+                "and retry."
             )
 
 


### PR DESCRIPTION
Right now we award any number of teammate requests that appear in a player's teammate request string. This PR changes the behavior so players are awarded for at most one teammate request.

A couple minor things batched into this PR:
* Fixing grade validation. Since #9 allowed having PreK and K grades as -1 and 0, we need to change the validation to allow this.
* adding location to the team repr