### PR TITLE
Add backup location

### DIFF
--- a/cyslf/models.py
+++ b/cyslf/models.py
@@ -38,6 +38,7 @@ class Player:
     preferred_days: str
     disallowed_locations: str
     preferred_locations: str
+    backup_locations: str
     teammate_requests: str
     lock: bool
     emailed_parents: bool
@@ -53,6 +54,7 @@ class Player:
             "preferred_days",
             "disallowed_locations",
             "preferred_locations",
+            "backup_locations",
             "teammate_requests",
         ]
         for key in str_keys:

--- a/cyslf/scorers/core.py
+++ b/cyslf/scorers/core.py
@@ -37,9 +37,29 @@ class PracticeDayScorer(CountScorer):
         return team.practice_day in player.preferred_days
 
 
-class LocationScorer(CountScorer):
-    def _count_player(self, player: "Player", team: "Team") -> bool:
-        return team.location in player.preferred_locations
+class LocationScorer:
+    def __init__(self, players: List["Player"], teams: List["Team"]):
+        self.league_size = len(players)
+        self.count = 0.0
+        for t in teams:
+            self.count += sum([self._count_player(p, t) for p in t.players])
+
+    def _count_player(self, player: "Player", team: "Team") -> float:
+        if team.location in player.preferred_locations:
+            return 1
+        elif team.location in player.backup_locations:
+            return 0.5
+        else:
+            return 0
+
+    def update_score_addition(self, player: "Player", team: "Team"):
+        self.count += self._count_player(player, team)
+
+    def update_score_removal(self, player: "Player", team: "Team"):
+        self.count -= self._count_player(player, team)
+
+    def get_score(self) -> float:
+        return self.count / self.league_size
 
 
 class TeammateScorer:

--- a/cyslf/utils.py
+++ b/cyslf/utils.py
@@ -14,10 +14,30 @@ DAY_MAP = {
 
 FIELD_MAP = {
     "East": ["Ahern", "Donnelly"],
-    "Central": ["Common"],
+    "Central": ["Common", "Sacramento"],
     "Cambridgeport": ["Pacific", "Magazine"],
     "West": ["Danehy", "Raymond", "Maher"],
     "North": ["Danehy", "Raymond", "Russell"],
+}
+
+
+def get_dist(x1, y1, x2, y2):
+    """Calculate the Euclidean distance between two points."""
+    return ((x1 - x2) ** 2 + (y1 - y2) ** 2) ** 0.5
+
+
+# These locations were pulled from google maps (lat, long)
+FIELD_LOCATIONS = {
+    "Ahern": (42.368859176331476, -71.08647586593241),
+    "Donnelly": (42.370366682994714, -71.0917891174976),
+    "Common": (42.37671780489148, -71.12093358866208),
+    "Pacific": (42.36053839550282, -71.10284706167454),
+    "Magazine": (42.35548441752288, -71.11382685798023),
+    "Danehy": (42.389099968964416, -71.13300644263798),
+    "Raymond": (42.38671764378315, -71.12781645797926),
+    "Maher": (42.38962880908857, -71.14937874050884),
+    "Sacramento": (42.38317187834224, -71.11773101380282),
+    "Russell": (42.39644583460877, -71.13739422914362),
 }
 
 # Threshold below which a player counts as a goalie

--- a/cyslf/validation.py
+++ b/cyslf/validation.py
@@ -91,7 +91,8 @@ def validate_player_locations(player: "Player"):
     # TODO: figure out how to strip strings to make the parsing more forgiving
     disallowed_locations = player.disallowed_locations.split(", ")
     preferred_locations = player.preferred_locations.split(", ")
-    for loc in disallowed_locations + preferred_locations:
+    backup_locations = player.backup_locations.split(", ")
+    for loc in disallowed_locations + preferred_locations + backup_locations:
         if len(loc) > 0 and loc not in valid_locations:
             raise ValueError(
                 f"Failed to create player {player.first_name} {player.last_name} due to invalid "


### PR DESCRIPTION
When players don't have a preferred location (or don't provide enough preferred locations), we'll give them "backup locations" -- the 3 field locations closest to their home address (found via geopy).

These have a weaker weight than preferred locations, but still factor into the score, so someone living in east cambridge will have an east cambridge preference even if they didn't fill out the parent request form.
